### PR TITLE
Fix a bug in bounds_checker client.

### DIFF
--- a/clients/watchpoints/clients/bounds_checker/bounds_checkers.asm
+++ b/clients/watchpoints/clients/bounds_checker/bounds_checkers.asm
@@ -92,7 +92,7 @@ END_FUNC(granary_detected_overflow)
     mov 4(%rsi), %rsi; @N@\
     sub $ size, %rsi; @N@\
     cmp %edi, %esi; @N@\
-    jmp .CAT(Lgranary_done_, size); @N@\
+    jge .CAT(Lgranary_done_, size); @N@\
 .CAT(Lgranary_underflow_, size): @N@\
     mov $ size, %rsi; @N@\
     jmp SHARED_SYMBOL(granary_detected_overflow); @N@\


### PR DESCRIPTION
Bug description: using unconditional 'jmp' after the 'cmp' between
'watched adress' and upper bounds.Thus overflow cannot be checked.

Fix: replace 'jmp' with 'jge'.
